### PR TITLE
Don't throw out Blossom5's stderr

### DIFF
--- a/impl/matchingAlgorithms.c
+++ b/impl/matchingAlgorithms.c
@@ -172,7 +172,7 @@ static stList *chooseAdjacencyPairing_externalProgram(stList *edges, int64_t nod
     /*
      * We run the external program.
      */
-    char *command = stString_print("%s -e %s -w %s > /dev/null 2>&1", programName, tempInputFile, tempOutputFile);
+    char *command = stString_print("%s -e %s -w %s > /dev/null", programName, tempInputFile, tempOutputFile);
     int64_t i = st_system(command);
     if(i != 0) {
         st_errAbort("Something went wrong with the command: %s", command);

--- a/tests/allTests.c
+++ b/tests/allTests.c
@@ -7,12 +7,16 @@
 #include "CuTest.h"
 #include "sonLib.h"
 
-CuSuite* referenceProblem2TestSuite(void);
+extern CuSuite* referenceProblem2TestSuite(void);
+extern CuSuite* cyclesConstrainedMatchingAlgorithmsTestSuite(void);
+extern CuSuite* matchingAlgorithmsTestSuite(void);
 
 int referenceRunAllTests(void) {
     CuString *output = CuStringNew();
     CuSuite* suite = CuSuiteNew();
     CuSuiteAddSuite(suite, referenceProblem2TestSuite());
+    CuSuiteAddSuite(suite, cyclesConstrainedMatchingAlgorithmsTestSuite());
+    CuSuiteAddSuite(suite, matchingAlgorithmsTestSuite());
 
     CuSuiteRun(suite);
     CuSuiteSummary(suite, output);


### PR DESCRIPTION
Cactus users are getting errors with blossom5 that are impossible to debug from the logs

ex 
https://github.com/ComparativeGenomicsToolkit/cactus/issues/872  
https://github.com/ComparativeGenomicsToolkit/cactus/issues/865 
https://github.com/ComparativeGenomicsToolkit/cactus/issues/860 
https://github.com/ComparativeGenomicsToolkit/cactus/issues/596

These seem, in some cases at least, to go beyond the known issue that it doesn't respect cactus's `--workDir` 
https://github.com/ComparativeGenomicsToolkit/cactus/issues/755

also, make sure the blososm5 test actually gets run as part of the suite...